### PR TITLE
Replacing rest parameters cause typescript interface ignore them.

### DIFF
--- a/packages/sol-rayz-react/src/hooks/useWalletNfts.ts
+++ b/packages/sol-rayz-react/src/hooks/useWalletNfts.ts
@@ -4,6 +4,7 @@ import {
   isValidSolanaAddress,
 } from "@nfteyez/sol-rayz";
 import type { Options } from "@nfteyez/sol-rayz";
+import { createConnectionConfig } from "@nfteyez/sol-rayz";
 
 import { NftTokenAccount, WalletResult } from "../types";
 
@@ -14,7 +15,11 @@ import { NftTokenAccount, WalletResult } from "../types";
  */
 export const useWalletNfts = ({
   publicAddress,
-  ...rest
+  connection = createConnectionConfig(),
+  sanitize = true,
+  strictNftStandard = false,
+  stringifyPubKeys = true,
+  sort = true
 }: Options): WalletResult => {
   const [nfts, setNfts] = useState<NftTokenAccount[]>([]);
   const [error, setError] = useState<unknown | undefined>();
@@ -39,7 +44,11 @@ export const useWalletNfts = ({
     try {
       const nfts = await getParsedNftAccountsByOwner({
         publicAddress,
-        ...rest,
+        connection,
+        sanitize,
+        strictNftStandard,
+        stringifyPubKeys,
+        sort
       });
       setNfts(nfts as any);
     } catch (error) {


### PR DESCRIPTION
Typescript ignores the rest parameters not adding them to the useWalletNfts interface and this doesn't allow to use those parameters.
I found the issue trying to pass a new connection to devnet and the resulting connection was mainnet. 